### PR TITLE
Update README with Flutter version guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Mat
-Matatu app for Matatu owners
+
+Matatu app for Matatu owners.
+
+## Getting Started
+
+This project targets Flutter SDK versions in the `>=3.24.0 <4.0.0` range, matching the `environment` constraints in `pubspec.yaml`. Make sure your local Flutter installation falls within that range (for example, Flutter 3.24.x) before running the app.
+
+Once Flutter is set up:
+
+```bash
+flutter pub get
+flutter run
+```


### PR DESCRIPTION
## Summary
- update the README getting started instructions to call out the supported Flutter SDK range (>=3.24.0 <4.0.0)

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ca45b047c08332b85589286bdc9842